### PR TITLE
Use stable gandi API url

### DIFF
--- a/example.cfg
+++ b/example.cfg
@@ -1,5 +1,5 @@
 [general]
-api = https://dns.beta.gandi.net/api/v5/
+api = https://dns.api.gandi.net/api/v5/
 api_key = <CHANGE_ME>
 
 [example_test]


### PR DESCRIPTION
The gandi api has changed its url for a more stable
one. Although https://dns.beta.gandi.net will continue to 
work for the foreseable future, this commits updates the
url to new official one.